### PR TITLE
Make macOS/Linux metanorma executable work with isodoc 1.0.23+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ else
   '~> 1.2'
 end
 
+gem 'iso-639', '0.2.10'
 gem 'metanorma-cli', mn_cli_version
 gem 'metanorma'
 gem 'metanorma-acme'
@@ -33,7 +34,7 @@ gem 'ruby-jing',
     ref: 'c28d0204766b502c2239799d2e2605c6d7d7778e'
 gem 'sassc',
     git: 'https://github.com/metanorma/sassc-ruby.git',
-    ref: '6e07d9634af0372006e8a5ea62bb80855cb69cb5'
+    ref: 'ce6c3a65b29247476ea1cf1c0f53cf7d5fe46827' # 6e07d9634af0372006e8a5ea62bb80855cb69cb5 - old one
 
 group :development do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/metanorma/sassc-ruby.git
-  revision: 6e07d9634af0372006e8a5ea62bb80855cb69cb5
-  ref: 6e07d9634af0372006e8a5ea62bb80855cb69cb5
+  revision: ce6c3a65b29247476ea1cf1c0f53cf7d5fe46827
+  ref: ce6c3a65b29247476ea1cf1c0f53cf7d5fe46827
   specs:
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -19,20 +19,25 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    asciidoctor (1.5.8)
+    asciidoctor (2.0.10)
     asciimath (1.0.9)
     ast (2.4.0)
-    byebug (11.0.1)
+    bibtex-ruby (5.1.4)
+      latex-decode (~> 0.0)
+    byebug (11.1.3)
     camertron-eprun (1.1.1)
     cldr-plurals-runtime-rb (1.0.1)
     cnccs (0.1.5)
-    concurrent-ruby (1.1.5)
-    faraday (0.17.0)
+    concurrent-ruby (1.1.6)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.2)
-    gb-agencies (0.0.5)
-    git (1.5.0)
-    html2doc (0.9.0)
+    ffi (1.12.2)
+    gb-agencies (0.0.6)
+    git (1.6.0)
+      rchardet (~> 1.8)
+    html2doc (1.0.0)
       asciimath (~> 1.0.9)
       htmlentities (~> 4.3.4)
       image_size
@@ -41,16 +46,19 @@ GEM
       thread_safe
       uuidtools
     htmlentities (4.3.4)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     iev (0.2.3)
       nokogiri (>= 1.10.4)
     image_size (2.0.2)
-    iso-639 (0.2.8)
-    isodoc (1.0.6)
+    iso-639 (0.2.10)
+    iso639 (1.3.2)
+    isodoc (1.0.24)
       asciimath
-      html2doc (~> 0.9.0)
+      html2doc (~> 1.0.0)
       htmlentities (~> 4.3.4)
       liquid
-      metanorma (~> 0.3.0)
+      metanorma (~> 1.0.0)
       nokogiri (>= 1.10.4)
       rake (~> 12.0)
       roman-numerals
@@ -59,37 +67,40 @@ GEM
       uuidtools
     isoics (0.1.8)
     jaro_winkler (1.5.4)
+    latex-decode (0.3.1)
     liquid (4.0.3)
-    metanorma (0.3.16)
+    mathml2asciimath (0.0.10)
+      htmlentities (~> 4.3.4)
+      nokogiri (>= 1.10.4)
+    metanorma (1.0.3)
       asciidoctor
       htmlentities
-    metanorma-acme (1.3.5)
-      asciidoctor (~> 1.5.7)
+      nokogiri
+    metanorma-acme (1.4.4)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
-    metanorma-cli (1.2.7.1)
+    metanorma-cli (1.2.11.1)
       git (~> 1.5)
       isodoc (~> 1.0.0)
-      metanorma (~> 0.3.9)
-      metanorma-acme (~> 1.3.0)
-      metanorma-csand (~> 1.3.0)
+      metanorma (~> 1.0.0)
+      metanorma-csa (~> 1.4.0)
       metanorma-csd (~> 1.3.0)
       metanorma-gb (~> 1.3.0)
-      metanorma-iec (~> 0.0.5)
-      metanorma-ietf (~> 1.0.1)
+      metanorma-generic (~> 1.4.0)
+      metanorma-iec (~> 1.0.0)
+      metanorma-ietf (~> 2.0.0)
       metanorma-iso (~> 1.3.0)
-      metanorma-itu (~> 0.2.0)
+      metanorma-itu (~> 1.0.0)
       metanorma-m3d (~> 1.3.0)
-      metanorma-nist (~> 0.2.0)
-      metanorma-ogc (~> 0.2.0)
-      metanorma-standoc (~> 1.3.0)
-      metanorma-unece (~> 0.2.0)
+      metanorma-nist (~> 1.0.0)
+      metanorma-ogc (~> 1.0.0)
+      metanorma-standoc (~> 1.3.0, >= 1.3.18)
+      metanorma-un (~> 0.3.1)
+      relaton-cli (>= 0.8.2)
       thor (~> 0.20.3)
-    metanorma-csand (1.3.5)
-      asciidoctor (~> 1.5.7)
-      asciimath
+    metanorma-csa (1.4.8)
       htmlentities (~> 4.3.4)
       image_size
       isodoc (~> 1.0.0)
@@ -98,36 +109,47 @@ GEM
       ruby-jing
       thread_safe
       uuidtools
-    metanorma-csd (1.3.5)
+    metanorma-csand (1.3.9)
+      htmlentities (~> 4.3.4)
+      image_size
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
-    metanorma-gb (1.3.6)
+      mime-types
+      ruby-jing
+      thread_safe
+      uuidtools
+    metanorma-csd (1.3.18)
+      isodoc (~> 1.0.0)
+      metanorma-standoc (~> 1.3.0)
+    metanorma-gb (1.3.21)
       gb-agencies (~> 0.0.4)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-iso (~> 1.3.0)
       twitter_cldr (~> 4.4.4)
-    metanorma-iec (0.0.9)
-      asciidoctor (~> 1.5.7)
-      isodoc (~> 1.0.0)
-      metanorma-iso (~> 1.3.0)
-      ruby-jing
-    metanorma-ietf (1.0.6)
-      isodoc (~> 1.0.0)
-      metanorma-standoc (~> 1.3.0)
-    metanorma-iso (1.3.6)
-      asciidoctor (~> 1.5.7)
-      isodoc (~> 1.0.0)
-      metanorma-standoc (~> 1.3.0)
-      ruby-jing
-    metanorma-itu (0.2.8)
-      asciidoctor (~> 1.5.7)
+    metanorma-generic (1.4.6)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
-    metanorma-m3d (1.3.5)
-      asciidoctor (~> 1.5.7)
+    metanorma-iec (1.0.4)
+      isodoc (~> 1.0.0)
+      metanorma-iso (~> 1.3.0)
+      ruby-jing
+    metanorma-ietf (2.0.8)
+      isodoc (~> 1.0.0)
+      mathml2asciimath
+      metanorma-standoc (~> 1.3.0)
+    metanorma-iso (1.3.22)
+      isodoc (~> 1.0.0)
+      metanorma-standoc (~> 1.3.0)
+      ruby-jing
+    metanorma-itu (1.0.13)
+      htmlentities (~> 4.3.4)
+      isodoc (~> 1.0.0)
+      metanorma-standoc (~> 1.3.0)
+      ruby-jing
+    metanorma-m3d (1.3.17)
       asciimath
       htmlentities (~> 4.3.4)
       image_size
@@ -137,46 +159,42 @@ GEM
       ruby-jing
       thread_safe
       uuidtools
-    metanorma-mpfd (0.3.5)
-      asciidoctor (~> 1.5.7)
+    metanorma-mpfd (0.3.17)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       twitter_cldr
-    metanorma-nist (0.2.3)
-      asciidoctor (~> 1.5.7)
+    metanorma-nist (1.0.5)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
       metanorma-standoc (~> 1.3.0)
       ruby-jing
       twitter_cldr
       tzinfo-data
-    metanorma-ogc (0.2.6)
-      asciidoctor (~> 1.5.7)
+    metanorma-ogc (1.0.4)
       htmlentities (~> 4.3.4)
       iso-639
-      isodoc (~> 1.0.0)
-      metanorma-standoc (~> 1.3.0)
+      isodoc (~> 1.0.20)
+      metanorma-standoc (~> 1.3.20)
       ruby-jing
-    metanorma-rsd (1.3.5)
-      asciidoctor (~> 1.5.7)
+    metanorma-rsd (1.4.4)
       htmlentities (~> 4.3.4)
       isodoc (~> 1.0.0)
+      metanorma-generic (~> 1.4.0)
       metanorma-standoc (~> 1.3.0)
-    metanorma-standoc (1.3.6)
-      asciidoctor (~> 1.5.7)
+    metanorma-standoc (1.3.24)
+      asciidoctor (~> 2.0.0)
       concurrent-ruby
-      html2doc (~> 0.9.0)
       iev (~> 0.2.1)
-      isodoc (~> 1.0.0)
+      isodoc (~> 1.0.20)
+      mathml2asciimath
       mimemagic
-      relaton (~> 0.5.0)
+      relaton (~> 0.11.0)
       relaton-iev (~> 0.1.0)
       ruby-jing
       sterile (~> 1.0.14)
       unicode2latex (~> 0.0.1)
-    metanorma-unece (0.2.7)
-      asciidoctor (~> 1.5.7)
+    metanorma-un (0.3.6)
       htmlentities (~> 4.3.4)
       iso-639
       isodoc (~> 1.0.0)
@@ -184,82 +202,116 @@ GEM
       roman-numerals
       ruby-jing
       twitter_cldr
-    mime-types (3.3)
+    metanorma-unece (0.2.14)
+      htmlentities (~> 4.3.4)
+      iso-639
+      isodoc (~> 1.0.0)
+      metanorma-standoc (~> 1.3.0)
+      roman-numerals
+      ruby-jing
+      twitter_cldr
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.3)
+    mimemagic (0.3.4)
     mini_portile2 (2.4.0)
     multipart-post (2.1.1)
-    nokogiri (1.10.5)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     optout (0.0.2)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
-    public_suffix (4.0.1)
+    public_suffix (4.0.4)
     rainbow (3.0.0)
     rake (12.3.3)
-    relaton (0.5.9)
-      relaton-gb (~> 0.6.0)
-      relaton-iec (~> 0.4.0)
-      relaton-ietf (~> 0.6.0)
-      relaton-iso (~> 0.6.0)
-      relaton-itu (~> 0.3.0)
-      relaton-nist (~> 0.3.0)
-      relaton-ogc (~> 0.1.0)
-    relaton-bib (0.3.12)
+    rchardet (1.8.0)
+    relaton (0.11.1)
+      relaton-calconnect (~> 0.7.0)
+      relaton-gb (~> 0.12.0)
+      relaton-iec (~> 0.10.0)
+      relaton-ietf (~> 0.12.0)
+      relaton-iso (~> 0.12.0)
+      relaton-itu (~> 0.9.0)
+      relaton-nist (~> 0.9.0)
+      relaton-ogc (~> 0.7.0)
+      relaton-omg (~> 0.3.0)
+      relaton-un (~> 0.2.0)
+      relaton-w3c (~> 0.1.0)
+    relaton-bib (0.9.2)
       addressable
+      bibtex-ruby
+      iso639
       nokogiri
-    relaton-gb (0.6.7)
+    relaton-calconnect (0.7.0)
+      faraday
+      relaton-iso-bib (~> 0.9.0)
+    relaton-cli (0.9.0)
+      liquid
+      relaton (~> 0.11.0)
+      thor
+    relaton-gb (0.12.0)
       cnccs (~> 0.1.1)
       gb-agencies (~> 0.0.1)
-      relaton-iso-bib (~> 0.3.0)
-    relaton-iec (0.4.10)
+      relaton-iso-bib (~> 0.9.0)
+    relaton-iec (0.10.0)
       addressable
-      relaton-iso-bib (~> 0.3.0)
-    relaton-ietf (0.6.8)
-      relaton-bib (~> 0.3.0)
-    relaton-iev (0.1.1)
-      relaton (~> 0.5.0)
-    relaton-iso (0.6.9)
-      relaton-iec (~> 0.4.0)
-      relaton-iso-bib (~> 0.3.0)
-    relaton-iso-bib (0.3.12)
+      relaton-iso-bib (~> 0.9.0)
+    relaton-ietf (0.12.1)
+      relaton-bib (~> 0.9.0)
+    relaton-iev (0.1.5)
+      relaton (~> 0.7)
+    relaton-iso (0.12.1)
+      relaton-iec (~> 0.10.0)
+      relaton-iso-bib (~> 0.9.0)
+    relaton-iso-bib (0.9.2)
       isoics (~> 0.1.6)
-      relaton-bib (~> 0.3.0)
-      ruby_deep_clone (~> 0.8.0)
-    relaton-itu (0.3.7)
-      relaton-iso-bib (~> 0.3.0)
-    relaton-nist (0.3.8)
-      relaton-bib (~> 0.3.0)
+      relaton-bib (~> 0.9.0)
+    relaton-itu (0.9.0)
+      relaton-iso-bib (~> 0.9.0)
+    relaton-nist (0.9.1)
+      relaton-bib (~> 0.9.0)
       rubyzip
-    relaton-ogc (0.1.4)
+    relaton-ogc (0.7.3)
+      faraday (~> 1.0.0)
+      relaton-iso-bib (>= 0.9.1)
+    relaton-omg (0.3.0)
+      relaton-bib (~> 0.9.0)
+    relaton-un (0.2.1)
       faraday
-      relaton-iso-bib (~> 0.3.0)
+      http-cookie
+      relaton-iso-bib (>= 0.9.2)
+      unf_ext (>= 0.0.7.7)
+    relaton-w3c (0.1.0)
+      relaton-bib (>= 0.9.2)
+    rexml (3.2.4)
     roman-numerals (0.3.0)
-    rubocop (0.76.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.10.1)
-    ruby_deep_clone (0.8.0)
-    rubyzip (2.0.0)
-    sterile (1.0.14)
-      nokogiri
+    rubyzip (2.3.0)
+    sterile (1.0.16)
+      nokogiri (>= 1.10.8)
     thor (0.20.3)
     thread_safe (0.3.6)
     twitter_cldr (4.4.5)
       camertron-eprun
       cldr-plurals-runtime-rb (~> 1.0)
       tzinfo
-    tzinfo (2.0.0)
+    tzinfo (2.0.2)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2019.3)
       tzinfo (>= 1.0.0)
-    unicode-display_width (1.6.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
+    unicode-display_width (1.7.0)
     unicode2latex (0.0.3)
     uuidtools (2.1.5)
 
@@ -268,6 +320,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  iso-639 (= 0.2.10)
   metanorma
   metanorma-acme
   metanorma-cli (~> 1.2)
@@ -289,4 +342,4 @@ DEPENDENCIES
   sassc!
 
 BUNDLED WITH
-   1.15.3
+   1.17.3


### PR DESCRIPTION
#23 

Updated all metanorma flavors gems to the latest versions, fixed compilation errors, for scss include issue i created a patch in scss fork: https://github.com/metanorma/sassc-ruby/commit/ce6c3a65b29247476ea1cf1c0f53cf7d5fe46827. After the update there is an issue with `iso-639` gem: for some reason, language file that they use is not read properly inside the compiled application, i was forced to downgrade gem version to 0.2.10.