### PR TITLE
Build metanorma-linux-x64 1.2.12

### DIFF
--- a/.github/workflows/compile_linux.yml
+++ b/.github/workflows/compile_linux.yml
@@ -43,9 +43,16 @@ jobs:
         GITHUB_CREDENTIALS: "metanorma-ci:${{ secrets.METANORMA_CI_PAT_TOKEN }}"
       run: make test
     - name: Copy release binary
+      if: ${{ always() }}
       run: mv build/metanorma metanorma-linux-x64
     - name: Set release binary permissions
+      if: ${{ always() }}
       run: chmod a+x metanorma-linux-x64
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: metanorma-linux-x64
+        path: metanorma-linux-x64
     - name: Release binary
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
 - DON'T MERGE, just to upload binary to release