### PR TITLE
Remove Sassc hack

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,12 +51,3 @@ from the `metanorma_entry_point` Ruby script.
 
 This script loads all dependencies in order to ruby packer
 correctly link all gems and their native extensions.
-
-
-== TODO
-
-Currently, it uses 2 forks of `sassc` and `ruby-jing` gems:
-
-* SassC was patched in order to load `libsass` bindings into
-  `memfs` of executable.
-* `ruby-jing` fork skips the usage of `jing` command completely.

--- a/bin/metanorma
+++ b/bin/metanorma
@@ -123,20 +123,6 @@ unless Gem.win_platform? # because on windows we use ocra
     end
   end
   # END of HACK
-
-  # HACK unpack saasc styles
-  begin
-    require 'sassc'
-    base_style = COMPILER_MEMFS_LIB_CACHE + 'base_style'
-    base_style.mkpath()
-    extract_memfs(File.join(Gem.loaded_specs['isodoc'].full_gem_path, 'lib', 'isodoc', 'base_style', '*.scss'), true, base_style)
-    SassC.load_paths << COMPILER_MEMFS_LIB_CACHE
-    SassC.load_paths << base_style
-    # TODO reveisit should we load ./metanorma-$flavor/lib/isodoc/$flavor/html/*.scss
-  rescue LoadError
-    puts "Skip extra SassC.load_paths"
-  end
-  # END of HACK
 end
 
 cert_file_path = nil


### PR DESCRIPTION
#61 since a few versions ago Metanorma no longer uses SassC at runtime so we don't need this hack anymore