### PR TITLE
#68 remove rubocopy because it doesn't support ruby 2.4

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Install dependencies
         run: brew install squashfs
       - name: run build
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
         run: make build
       - uses: actions/upload-artifact@v2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'metanorma-ribose'
 
 group :development do
   gem 'byebug'
-  gem 'rubocop'
 end
 
 gem "metanorma-cli", "= 1.3.8.1pre"


### PR DESCRIPTION
 - #68 