### PR TITLE
ubuntu-16.04 removed from GitHub Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
 
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-16.04, ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
         ignore-errors: [ false ]
         test-flavor:
           - iso


### PR DESCRIPTION
GitHub Actions now doesn't support ubuntu-16.04

 - https://github.com/actions/virtual-environments/issues/3287
 - https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1604-README.md

@ronaldtse please let me know if it critical for us to support ubuntu-16.04