### PR TITLE
Fix GHA macOS to use macos-10.15

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,8 +2,7 @@ name: linux
 
 on:
   push:
-    branches: [ master ]
-    tags: [ '*' ]
+    branches: [ main ]
   pull_request:
     paths-ignore:
       - .github/workflows/macos.yml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
       with:
@@ -68,7 +68,7 @@ jobs:
     continue-on-error: ${{ matrix.ignore-errors }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         os: [ ubuntu-18.04, ubuntu-20.04 ]
         ignore-errors: [ false ]
@@ -78,15 +78,15 @@ jobs:
           - un
           - iec
           - iho
-          - m3aawg
-          - jcgm
+          # - m3aawg
+          # - jcgm
           - csa
           - bipm
-          - itu
+          # - itu
           - ietf
           - ogc
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/download-artifact@v2
         with:
@@ -95,7 +95,9 @@ jobs:
 
       - run: chmod +x build/metanorma
 
-      - run: make test-flavor
+      - name: Test processing for ${{ matrix.test-flavor }}
+        timeout-minutes: 30
+        run: make test-flavor
         env:
           GITHUB_CREDENTIALS: "metanorma-ci:${{ secrets.METANORMA_CI_PAT_TOKEN }}"
           TEST_FLAVOR: ${{ matrix.test-flavor }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,7 +96,7 @@ jobs:
       - run: chmod +x build/metanorma
 
       - name: Test processing for ${{ matrix.test-flavor }}
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: make test-flavor
         env:
           GITHUB_CREDENTIALS: "metanorma-ci:${{ secrets.METANORMA_CI_PAT_TOKEN }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,6 +69,7 @@ jobs:
     continue-on-error: ${{ matrix.ignore-errors }}
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         os: [ ubuntu-18.04, ubuntu-20.04 ]
         ignore-errors: [ false ]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: macos-10.15
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: metanorma/metanorma-build-scripts/gh-rubygems-setup-action@master
         with:
@@ -57,7 +57,7 @@ jobs:
     continue-on-error: ${{ matrix.ignore-errors }}
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         os: [ macos-11.0 ]
         ignore-errors: [ false ]
@@ -67,15 +67,15 @@ jobs:
           - un
           - iec
           - iho
-          - m3aawg
-          - jcgm
+          # - m3aawg
+          # - jcgm
           - csa
           - bipm
-          - itu
+          # - itu
           - ietf
           - ogc
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/download-artifact@v2
         with:
@@ -84,7 +84,9 @@ jobs:
 
       - run: chmod a+x build/metanorma
 
-      - run: make test-flavor
+      - name: Test processing for ${{ matrix.test-flavor }}
+        timeout-minutes: 30
+        run: make test-flavor
         env:
           GITHUB_CREDENTIALS: "metanorma-ci:${{ secrets.METANORMA_CI_PAT_TOKEN }}"
           TEST_FLAVOR: ${{ matrix.test-flavor }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,7 @@ jobs:
     continue-on-error: ${{ matrix.ignore-errors }}
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         os: [ macos-10.15 ]
         ignore-errors: [ false ]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        os: [ macos-10.15 ]
+        os: [ macos-11.0 ]
         ignore-errors: [ false ]
         test-flavor:
           - iso
@@ -75,41 +75,6 @@ jobs:
           - itu
           - ietf
           - ogc
-        include:
-          # macos-11.0 looks not working
-          - test-flavor: iso
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: cc
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: un
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: iec
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: iho
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: m3aawg
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: jcgm
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: csa
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: bipm
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: itu
-            ignore-errors: true
-            os: macos-11.0
-          - test-flavor: ietf
-            ignore-errors: true
-            os: macos-11.0
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,8 +2,7 @@ name: macos
 
 on:
   push:
-    branches: [ master ]
-    tags: [ '*' ]
+    branches: [ main ]
   pull_request:
     paths-ignore:
       - .github/workflows/linux.yml

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     if: startsWith(github.event.client_payload.ref, 'refs/tags/v')
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Add writable remote
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,8 +2,7 @@ name: windows
 
 on:
   push:
-    branches: [ master ]
-    tags: [ '*' ]
+    branches: [ main ]
   pull_request:
     paths-ignore:
       - .github/workflows/linux.yml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - run: |
         gem -v
@@ -55,6 +55,7 @@ jobs:
     continue-on-error: ${{ matrix.ignore-errors }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         ignore-errors: [ false ]
         test-flavor:
@@ -63,18 +64,19 @@ jobs:
           - un
           - iec
           - iho
-          - m3aawg
-          - jcgm
+          # - m3aawg
+          # - jcgm
           - csa
           - bipm
+          # - itu
           - ietf
           - ogc
-        include:
-          # timeout www.iso.com happens
-          - test-flavor: itu
-            ignore-errors: true
+        # include:
+        #   # timeout www.iso.com happens
+        #   - test-flavor: itu
+        #     ignore-errors: true
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/download-artifact@v2
         with:
@@ -88,7 +90,9 @@ jobs:
           max_attempts: 3
           command: choco install --no-progress make
 
-      - run: |
+      - name: Test processing for ${{ matrix.test-flavor }}
+        timeout-minutes: 30
+        run: |
           Remove-Item Gemfile
           & ${env:ChocolateyInstall}\bin\make.exe -f Makefile.win test-flavor SHELL=cmd
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /relaton
 /site
 /Gemfile.lock
+/vendor/cacert.pem.mozilla

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ TEST_PROCESSORS ?= iso cc iec un m3aawg jcgm csa bipm iho ogc itu ietf
 
 BUILD_DIR := build
 
+all: $(BUILD_DIR)/metanorma
+
 rubyc:
 	curl -L https://github.com/metanorma/ruby-packer/releases/download/v0.6.1/rubyc-$(PLATFORM)-x64 \
 	  -o $@ && \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!make
 SHELL := /bin/bash
 
-.PHONY: build test png2ico
+.PHONY: build test
 
 ifeq ($(OS),Windows_NT)
   PLATFORM := windows
@@ -47,5 +47,5 @@ test-flavor: build/metanorma
 clean:
 	[ -d $(BUILD_DIR) ] || mkdir $(BUILD_DIR); rm -rf $(BUILD_DIR)/* || true
 
-png2ico:
-	convert ocra/icon.png -define icon:auto-resize="256,128,96,64,48,32,16" ocra/metanorma.ico
+ocra/metanorma.ico:
+	convert ocra/icon.png -define icon:auto-resize="256,128,96,64,48,32,16"

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ clean:
 	[ -d $(BUILD_DIR) ] || mkdir $(BUILD_DIR); rm -rf $(BUILD_DIR)/* || true
 
 ocra/metanorma.ico:
-	convert ocra/icon.png -define icon:auto-resize="256,128,96,64,48,32,16"
+	convert ocra/icon.png -define icon:auto-resize="256,128,96,64,48,32,16" $@

--- a/bin/metanorma
+++ b/bin/metanorma
@@ -175,14 +175,11 @@ if Gem.win_platform?
   require 'ffi-libarchive-binary' # to preload libarchive-13.dll
 end
 
-@@global_cert_store = OpenSSL::X509::Store.new
-@@global_cert_store.add_file cert_file_path
-
 Net::HTTP.class_eval do
   alias _use_ssl= use_ssl=
 
   def use_ssl= boolean
-    self.cert_store = @@global_cert_store
+    self.ca_file = cert_file_path
     self.verify_mode = OpenSSL::SSL::VERIFY_PEER
     self._use_ssl = boolean
   end

--- a/bin/metanorma
+++ b/bin/metanorma
@@ -175,6 +175,16 @@ if Gem.win_platform?
   require 'ffi-libarchive-binary' # to preload libarchive-13.dll
 end
 
+Net::HTTP.class_eval do
+  alias _use_ssl= use_ssl=
+
+  def use_ssl= boolean
+    self.ca_file = cert_file_path
+    self.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    self._use_ssl = boolean
+  end
+end
+
 # explicitly load all dependent gems
 # ruby packer cannot use gem load path correctly.
 require 'isodoc'

--- a/bin/metanorma
+++ b/bin/metanorma
@@ -175,16 +175,6 @@ if Gem.win_platform?
   require 'ffi-libarchive-binary' # to preload libarchive-13.dll
 end
 
-Net::HTTP.class_eval do
-  alias _use_ssl= use_ssl=
-
-  def use_ssl= boolean
-    self.ca_file = cert_file_path
-    self.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    self._use_ssl = boolean
-  end
-end
-
 # explicitly load all dependent gems
 # ruby packer cannot use gem load path correctly.
 require 'isodoc'

--- a/bin/metanorma
+++ b/bin/metanorma
@@ -175,11 +175,14 @@ if Gem.win_platform?
   require 'ffi-libarchive-binary' # to preload libarchive-13.dll
 end
 
+@@global_cert_store = OpenSSL::X509::Store.new
+@@global_cert_store.add_file cert_file_path
+
 Net::HTTP.class_eval do
   alias _use_ssl= use_ssl=
 
   def use_ssl= boolean
-    self.ca_file = cert_file_path
+    self.cert_store = @@global_cert_store
     self.verify_mode = OpenSSL::SSL::VERIFY_PEER
     self._use_ssl = boolean
   end

--- a/bin/metanorma
+++ b/bin/metanorma
@@ -10,6 +10,9 @@ require 'tempfile'
 
 COMPILER_MEMFS = '/__ruby_packer_memfs__'
 
+# Limit Relaton to concurrent fetches of 1
+ENV["RELATON_FETCH_PARALLEL"] = "1"
+
 def determine_cert_path
   return "#{File.expand_path(File.dirname(__FILE__))}/cacert.pem.mozilla" if Gem.win_platform?
 


### PR DESCRIPTION
### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->

GHA has **just** (today) switched the default `macos-latest` to `macos-11`, causing failures here: https://github.com/metanorma/packed-mn/runs/4439042422?check_suite_focus=true
* https://github.com/actions/virtual-environments/issues/4060

So let's first fix to the older version and address the upgrade.