### PR TITLE
Bumped Ruby version from 2.7 to 3.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,8 +67,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
-        rubygems: '3.3.22'
+        ruby-version: '3.1'
 
     - uses: nick-invision/retry@v2
       with:


### PR DESCRIPTION
Ruby version change since 2.7 is eol
Windows Ruby version aligned with Linux version thanks to aibika

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
