### PR TITLE
fix: gem 'openssl', '= 3.0.2' because of  https://github.com/tamateba…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ if Gem.win_platform?
 end
 
 gem "ffi"
+gem "openssl", "= 3.0.2"
 # nokogiry asks for psych >= 4
 # psych 5 does not support --enable-bundled-libyaml configuration option
 # that is required by tebako

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ if Gem.win_platform?
 end
 
 gem "ffi"
-gem "openssl", "= 3.0.2"
+gem "openssl", "= 3.0.2" # Pinned due to compatibility issues with later versions; see https://github.com/metanorma/packed-mn/issues/XX
 # nokogiry asks for psych >= 4
 # psych 5 does not support --enable-bundled-libyaml configuration option
 # that is required by tebako

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,11 @@ if Gem.win_platform?
   gem "fontist"
   gem "net-ssh"
   gem "zlib"
+else
+  gem "openssl", "= 3.0.2" # Pinned due to compatibility issues with later versions; see https://github.com/metanorma/packed-mn/issues/XX
 end
 
 gem "ffi"
-gem "openssl", "= 3.0.2" # Pinned due to compatibility issues with later versions; see https://github.com/metanorma/packed-mn/issues/XX
 # nokogiry asks for psych >= 4
 # psych 5 does not support --enable-bundled-libyaml configuration option
 # that is required by tebako


### PR DESCRIPTION
…ko/tebako/issues/329

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
